### PR TITLE
[core] implement basic rendering logic and movement controls

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -4,6 +4,6 @@ public class Main {
     public static void main(String[] args) {
         System.out.println("Starting Engine");
         Engine engine = new Engine();
-        engine.singleFrameTest();
+        engine.mainLoop();
     }
 }

--- a/src/Main.java
+++ b/src/Main.java
@@ -1,0 +1,9 @@
+import engine.Engine;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Starting Engine");
+        Engine engine = new Engine();
+        engine.singleFrameTest();
+    }
+}

--- a/src/engine/Engine.java
+++ b/src/engine/Engine.java
@@ -4,6 +4,7 @@ import edu.princeton.cs.algs4.StdDraw;
 import world.World;
 import world.Cube;
 import world.Camera;
+import world.Entity;
 
 /**
  * Class that handles the overarching operations of the project.
@@ -12,6 +13,7 @@ import world.Camera;
 public class Engine {
 
     Renderer ter = new Renderer();
+    Camera camera;
     public final int DISPLAY_WIDTH = 600;
     public final int DISPLAY_HEIGHT = 600;
     public final int VERTICAL_VIEW_ANGLE = 60;
@@ -21,7 +23,7 @@ public class Engine {
      * */
     public void singleFrameTest() {
         World world = new World();
-        Camera camera = new Camera(0, 0, 0);
+        camera = new Camera(0, 0, 0);
         Cube cube = new Cube(-50, -50, 100, 60);
         world.insertEntity(cube);
         ter.initialize(camera, DISPLAY_WIDTH, DISPLAY_HEIGHT, VERTICAL_VIEW_ANGLE);
@@ -30,7 +32,7 @@ public class Engine {
 
     public void mainLoop() {
         World world = new World();
-        Camera camera = new Camera(0, 0, 0);
+        camera = new Camera(0, 0, 0);
         Cube cube = new Cube(0, 0, 100, 60);
         world.insertEntity(cube);
         ter.initialize(camera, DISPLAY_WIDTH, DISPLAY_HEIGHT, VERTICAL_VIEW_ANGLE);
@@ -38,33 +40,65 @@ public class Engine {
             ter.renderFrame(world);
             if (StdDraw.hasNextKeyTyped()) {
                 char keyPress = StdDraw.nextKeyTyped();
-                switch (keyPress) {
-                    case 'w' -> {
-                        camera.moveFrontal(10);
-                    }
-                    case 's' -> {
-                        camera.moveFrontal(-10);
-                    }
-                    case 'd' -> {
-                        camera.moveLateral(10);
-                    }
-                    case 'a' -> {
-                        camera.moveLateral(-10);
-                    }
-                    case 'i' -> {
-                        camera.rotatePitch(-10);
-                    }
-                    case 'k' -> {
-                        camera.rotatePitch(10);
-                    }
-                    case 'l' -> {
-                        camera.rotateYaw(10);
-                    }
-                    case 'j' -> {
-                        camera.rotateYaw(-10);
-                    }
+                boolean isTargetLocked = true;
+                if (isTargetLocked) {
+                    fixedOrbitalMovement(cube, keyPress);
+                } else {
+                    freeMovement(keyPress);
                 }
             }
         }
+    }
+
+    public void fixedOrbitalMovement(Entity target, char keyPress) {
+        switch (keyPress) {
+            case 'w' -> {
+                camera.moveFrontal(10);
+            }
+            case 's' -> {
+                camera.moveFrontal(-10);
+            }
+            case 'd' -> {
+                camera.rotateAround(target, 10);
+            }
+            case 'a' -> {
+                camera.rotateAround(target, -10);
+            }
+        }
+    }
+
+    public void freeMovement(char keyPress) {
+        switch (keyPress) {
+            case 'w' -> {
+                camera.moveFrontal(10);
+            }
+            case 's' -> {
+                camera.moveFrontal(-10);
+            }
+            case 'd' -> {
+                camera.moveLateral(10);
+            }
+            case 'a' -> {
+                camera.moveLateral(-10);
+            }
+            case 'i' -> {
+                camera.rotatePitch(-10);
+            }
+            case 'k' -> {
+                camera.rotatePitch(10);
+            }
+            case 'l' -> {
+                camera.rotateYaw(10);
+            }
+            case 'j' -> {
+                camera.rotateYaw(-10);
+            }
+            case 'q' -> {
+                camera.moveTransverse(10);
+            }
+            case 'e' -> {
+                camera.moveTransverse(-10);
+            }
+        };
     }
 }

--- a/src/engine/Engine.java
+++ b/src/engine/Engine.java
@@ -51,6 +51,18 @@ public class Engine {
                     case 'a' -> {
                         camera.moveLateral(-10);
                     }
+                    case 'i' -> {
+                        camera.rotatePitch(-10);
+                    }
+                    case 'k' -> {
+                        camera.rotatePitch(10);
+                    }
+                    case 'l' -> {
+                        camera.rotateYaw(10);
+                    }
+                    case 'j' -> {
+                        camera.rotateYaw(-10);
+                    }
                 }
             }
         }

--- a/src/engine/Engine.java
+++ b/src/engine/Engine.java
@@ -1,7 +1,7 @@
 package engine;
 
 import org.checkerframework.checker.units.qual.C;
-import world.Cube;
+import world.Square;
 import world.World;
 
 /**
@@ -14,15 +14,29 @@ public class Engine {
     // display dimensions in number of pixels.
     public final int DISPLAY_WIDTH = 600;
     public final int DISPLAY_HEIGHT = 600;
+    // depth of the near clipping plane
+    public int near = 50;
+    // depth of the far clipping plane
+    public int far = 300;
+    public double aspect = (double) DISPLAY_WIDTH / DISPLAY_HEIGHT;
 
     /**
      * Test function for rendering individual scenes.
      * */
     public void singleFrameTest() {
         World world = new World();
-        Cube cube = new Cube(100, 100, 0, 100);
-        world.insertEntity(cube);
+        Square frontFace = new Square(0, 0, 100, 100);
+        Square topFace = new Square(200, 0, 200, 100);
+        world.insertEntity(frontFace);
+        world.insertEntity(topFace);
         ter.initialize(DISPLAY_WIDTH, DISPLAY_HEIGHT);
         ter.renderFrame(world);
+    }
+
+    public int fetchCenterX() {
+        return DISPLAY_WIDTH / 2;
+    }
+    public int fetchCenterY() {
+        return DISPLAY_HEIGHT / 2;
     }
 }

--- a/src/engine/Engine.java
+++ b/src/engine/Engine.java
@@ -1,0 +1,24 @@
+package engine;
+
+import world.World;
+
+/**
+ * Class that handles the overarching operations of the project.
+ * Solicits user input, captures the world state, and renders each frame.
+ * */
+public class Engine {
+
+    Renderer ter = new Renderer();
+    // display dimensions in number of pixels.
+    public final int DISPLAY_WIDTH = 600;
+    public final int DISPLAY_HEIGHT = 600;
+
+    /**
+     * Test function for rendering individual scenes.
+     * */
+    public void singleFrameTest() {
+        World world = new World();
+        ter.initialize(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+        ter.renderFrame(world);
+    }
+}

--- a/src/engine/Engine.java
+++ b/src/engine/Engine.java
@@ -1,7 +1,5 @@
 package engine;
 
-import org.checkerframework.checker.units.qual.C;
-import world.Square;
 import world.World;
 import world.Cube;
 
@@ -12,34 +10,18 @@ import world.Cube;
 public class Engine {
 
     Renderer ter = new Renderer();
-    // display dimensions in number of pixels.
     public final int DISPLAY_WIDTH = 600;
     public final int DISPLAY_HEIGHT = 600;
-    // depth of the near clipping plane
-    public int near = 50;
-    // depth of the far clipping plane
-    public int far = 300;
-    public double aspect = (double) DISPLAY_WIDTH / DISPLAY_HEIGHT;
+    public final int VERTICAL_VIEW_ANGLE = 60;
 
     /**
      * Test function for rendering individual scenes.
      * */
     public void singleFrameTest() {
         World world = new World();
-//        Square frontFace = new Square(0, 0, 100, 100);
-//        Square topFace = new Square(200, 0, 200, 100);
-//        world.insertEntity(frontFace);
-//        world.insertEntity(topFace);
-        Cube cube = new Cube(-60, -60, 100, 60);
+        Cube cube = new Cube(-50, -50, 100, 60);
         world.insertEntity(cube);
-        ter.initialize(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+        ter.initialize(DISPLAY_WIDTH, DISPLAY_HEIGHT, VERTICAL_VIEW_ANGLE);
         ter.renderFrame(world);
-    }
-
-    public int fetchCenterX() {
-        return DISPLAY_WIDTH / 2;
-    }
-    public int fetchCenterY() {
-        return DISPLAY_HEIGHT / 2;
     }
 }

--- a/src/engine/Engine.java
+++ b/src/engine/Engine.java
@@ -1,5 +1,7 @@
 package engine;
 
+import org.checkerframework.checker.units.qual.C;
+import world.Cube;
 import world.World;
 
 /**
@@ -18,6 +20,8 @@ public class Engine {
      * */
     public void singleFrameTest() {
         World world = new World();
+        Cube cube = new Cube(100, 100, 0, 100);
+        world.insertEntity(cube);
         ter.initialize(DISPLAY_WIDTH, DISPLAY_HEIGHT);
         ter.renderFrame(world);
     }

--- a/src/engine/Engine.java
+++ b/src/engine/Engine.java
@@ -53,13 +53,16 @@ public class Engine {
                 if (!isTargetLocked) {
                     fixedOrbitalMovement(cube1, keyPress);
                 } else {
-                    freeMovement(keyPress);
+                    freeMovement(cube1, keyPress);
                 }
             }
         }
     }
-    public void freeMovement(char keyPress) {
+    public void freeMovement(Entity target, char keyPress) {
         switch (keyPress) {
+            case 'u' -> {
+                camera.pointToward(target);
+            }
             case 'w' -> {
                 camera.moveFrontal(10);
             }
@@ -73,10 +76,10 @@ public class Engine {
                 camera.moveLateral(-10);
             }
             case 'i' -> {
-                camera.rotatePitch(-10);
+                camera.rotatePitch(10);
             }
             case 'k' -> {
-                camera.rotatePitch(10);
+                camera.rotatePitch(-10);
             }
             case 'l' -> {
                 camera.rotateYaw(-10);

--- a/src/engine/Engine.java
+++ b/src/engine/Engine.java
@@ -5,6 +5,7 @@ import world.World;
 import world.Cube;
 import world.Camera;
 import world.Entity;
+import util.Coordinate;
 
 /**
  * Class that handles the overarching operations of the project.
@@ -24,8 +25,12 @@ public class Engine {
     public void singleFrameTest() {
         World world = new World();
         camera = new Camera(0, 0, 0);
-        Cube cube = new Cube(-50, -50, 100, 60);
-        world.insertEntity(cube);
+        Cube cube1 = new Cube(0, 0, 100, 50);
+        Cube cube2 = new Cube(0, 50, 100, 50);
+        Cube cube3 = new Cube(50, 0, 100, 50);
+        world.insertEntity(cube1);
+        world.insertEntity(cube2);
+        world.insertEntity(cube3);
         ter.initialize(camera, DISPLAY_WIDTH, DISPLAY_HEIGHT, VERTICAL_VIEW_ANGLE);
         ter.renderFrame(world);
     }
@@ -33,40 +38,26 @@ public class Engine {
     public void mainLoop() {
         World world = new World();
         camera = new Camera(0, 0, 0);
-        Cube cube = new Cube(0, 0, 100, 60);
-        world.insertEntity(cube);
+        Cube cube1 = new Cube(0, 0, 100, 50);
+        Cube cube2 = new Cube(0, 50, 100, 50);
+        Cube cube3 = new Cube(50, 0, 100, 50);
+        world.insertEntity(cube1);
+        world.insertEntity(cube2);
+        world.insertEntity(cube3);
         ter.initialize(camera, DISPLAY_WIDTH, DISPLAY_HEIGHT, VERTICAL_VIEW_ANGLE);
         while (true) {
             ter.renderFrame(world);
             if (StdDraw.hasNextKeyTyped()) {
                 char keyPress = StdDraw.nextKeyTyped();
                 boolean isTargetLocked = true;
-                if (isTargetLocked) {
-                    fixedOrbitalMovement(cube, keyPress);
+                if (!isTargetLocked) {
+                    fixedOrbitalMovement(cube1, keyPress);
                 } else {
                     freeMovement(keyPress);
                 }
             }
         }
     }
-
-    public void fixedOrbitalMovement(Entity target, char keyPress) {
-        switch (keyPress) {
-            case 'w' -> {
-                camera.moveFrontal(10);
-            }
-            case 's' -> {
-                camera.moveFrontal(-10);
-            }
-            case 'd' -> {
-                camera.rotateAround(target, 10);
-            }
-            case 'a' -> {
-                camera.rotateAround(target, -10);
-            }
-        }
-    }
-
     public void freeMovement(char keyPress) {
         switch (keyPress) {
             case 'w' -> {
@@ -88,10 +79,10 @@ public class Engine {
                 camera.rotatePitch(10);
             }
             case 'l' -> {
-                camera.rotateYaw(10);
+                camera.rotateYaw(-10);
             }
             case 'j' -> {
-                camera.rotateYaw(-10);
+                camera.rotateYaw(10);
             }
             case 'q' -> {
                 camera.moveTransverse(10);
@@ -100,5 +91,21 @@ public class Engine {
                 camera.moveTransverse(-10);
             }
         };
+    }
+    public void fixedOrbitalMovement(Entity target, char keyPress) {
+        switch (keyPress) {
+            case 'w' -> {
+                camera.moveFrontal(-10);
+            }
+            case 's' -> {
+                camera.moveFrontal(10);
+            }
+            case 'd' -> {
+                camera.rotateAround(target, 10);
+            }
+            case 'a' -> {
+                camera.rotateAround(target, -10);
+            }
+        }
     }
 }

--- a/src/engine/Engine.java
+++ b/src/engine/Engine.java
@@ -1,7 +1,9 @@
 package engine;
 
+import edu.princeton.cs.algs4.StdDraw;
 import world.World;
 import world.Cube;
+import world.Camera;
 
 /**
  * Class that handles the overarching operations of the project.
@@ -19,9 +21,38 @@ public class Engine {
      * */
     public void singleFrameTest() {
         World world = new World();
+        Camera camera = new Camera(0, 0, 0);
         Cube cube = new Cube(-50, -50, 100, 60);
         world.insertEntity(cube);
-        ter.initialize(DISPLAY_WIDTH, DISPLAY_HEIGHT, VERTICAL_VIEW_ANGLE);
+        ter.initialize(camera, DISPLAY_WIDTH, DISPLAY_HEIGHT, VERTICAL_VIEW_ANGLE);
         ter.renderFrame(world);
+    }
+
+    public void mainLoop() {
+        World world = new World();
+        Camera camera = new Camera(0, 0, 0);
+        Cube cube = new Cube(0, 0, 100, 60);
+        world.insertEntity(cube);
+        ter.initialize(camera, DISPLAY_WIDTH, DISPLAY_HEIGHT, VERTICAL_VIEW_ANGLE);
+        while (true) {
+            ter.renderFrame(world);
+            if (StdDraw.hasNextKeyTyped()) {
+                char keyPress = StdDraw.nextKeyTyped();
+                switch (keyPress) {
+                    case 'w' -> {
+                        camera.moveFrontal(10);
+                    }
+                    case 's' -> {
+                        camera.moveFrontal(-10);
+                    }
+                    case 'd' -> {
+                        camera.moveLateral(10);
+                    }
+                    case 'a' -> {
+                        camera.moveLateral(-10);
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/engine/Engine.java
+++ b/src/engine/Engine.java
@@ -50,7 +50,7 @@ public class Engine {
             if (StdDraw.hasNextKeyTyped()) {
                 char keyPress = StdDraw.nextKeyTyped();
                 boolean isTargetLocked = true;
-                if (!isTargetLocked) {
+                if (isTargetLocked) {
                     fixedOrbitalMovement(cube1, keyPress);
                 } else {
                     freeMovement(cube1, keyPress);
@@ -98,10 +98,10 @@ public class Engine {
     public void fixedOrbitalMovement(Entity target, char keyPress) {
         switch (keyPress) {
             case 'w' -> {
-                camera.moveFrontal(-10);
+                camera.moveFrontal(10);
             }
             case 's' -> {
-                camera.moveFrontal(10);
+                camera.moveFrontal(-10);
             }
             case 'd' -> {
                 camera.rotateAround(target, 10);

--- a/src/engine/Engine.java
+++ b/src/engine/Engine.java
@@ -3,6 +3,7 @@ package engine;
 import org.checkerframework.checker.units.qual.C;
 import world.Square;
 import world.World;
+import world.Cube;
 
 /**
  * Class that handles the overarching operations of the project.
@@ -25,10 +26,12 @@ public class Engine {
      * */
     public void singleFrameTest() {
         World world = new World();
-        Square frontFace = new Square(0, 0, 100, 100);
-        Square topFace = new Square(200, 0, 200, 100);
-        world.insertEntity(frontFace);
-        world.insertEntity(topFace);
+//        Square frontFace = new Square(0, 0, 100, 100);
+//        Square topFace = new Square(200, 0, 200, 100);
+//        world.insertEntity(frontFace);
+//        world.insertEntity(topFace);
+        Cube cube = new Cube(-60, -60, 100, 60);
+        world.insertEntity(cube);
         ter.initialize(DISPLAY_WIDTH, DISPLAY_HEIGHT);
         ter.renderFrame(world);
     }

--- a/src/engine/Engine.java
+++ b/src/engine/Engine.java
@@ -75,6 +75,12 @@ public class Engine {
             case 'a' -> {
                 camera.moveLateral(-10);
             }
+            case 'q' -> {
+                camera.moveTransverse(10);
+            }
+            case 'e' -> {
+                camera.moveTransverse(-10);
+            }
             case 'i' -> {
                 camera.rotatePitch(10);
             }
@@ -86,12 +92,6 @@ public class Engine {
             }
             case 'j' -> {
                 camera.rotateYaw(10);
-            }
-            case 'q' -> {
-                camera.moveTransverse(10);
-            }
-            case 'e' -> {
-                camera.moveTransverse(-10);
             }
         };
     }
@@ -108,6 +108,24 @@ public class Engine {
             }
             case 'a' -> {
                 camera.rotateAround(target, -10);
+            }
+            case 'q' -> {
+                camera.moveTransverse(10);
+            }
+            case 'e' -> {
+                camera.moveTransverse(-10);
+            }
+            case 'i' -> {
+                camera.rotatePitch(10);
+            }
+            case 'k' -> {
+                camera.rotatePitch(-10);
+            }
+            case 'l' -> {
+                camera.rotateYaw(-10);
+            }
+            case 'j' -> {
+                camera.rotateYaw(10);
             }
         }
     }

--- a/src/engine/Renderer.java
+++ b/src/engine/Renderer.java
@@ -1,0 +1,47 @@
+package engine;
+
+import edu.princeton.cs.algs4.StdDraw;
+import world.Entity;
+import world.World;
+
+import java.awt.Color;
+
+public class Renderer {
+    private int width;
+    private int height;
+
+    /**
+     * Initializes StdDraw parameters and launches the StdDraw window. w and h are the
+     * width and height of the world in pixels.
+     *
+     * @param w width of the window in pixels.
+     * @param h height of the window in pixels.
+     */
+    public void initialize(int w, int h) {
+        this.width = w;
+        this.height = h;
+        StdDraw.setCanvasSize(width, height);
+
+        StdDraw.setXscale(0, width);
+        StdDraw.setYscale(0, height);
+
+        StdDraw.clear(new Color(0, 0, 0));
+
+        StdDraw.enableDoubleBuffering();
+        StdDraw.show();
+    }
+
+    /**
+     * Bare-bones render method. Calls the render method of each individual entity.
+     *
+     * @param world current world state to be rendered.
+     * */
+    public void renderFrame(World world) {
+        StdDraw.clear(new Color(0, 0, 0));
+        for (Entity entity : world.fetchEntities()) {
+            entity.render();
+        }
+        StdDraw.show();
+    }
+}
+

--- a/src/engine/Renderer.java
+++ b/src/engine/Renderer.java
@@ -1,48 +1,132 @@
 package engine;
 
 import edu.princeton.cs.algs4.StdDraw;
+import util.Coordinate;
+import util.Mesh;
 import world.Entity;
 import world.World;
 
 import java.awt.Color;
+import java.util.PriorityQueue;
 
 public class Renderer {
-    private int width;
-    private int height;
+    /**
+     * `MeshRankNode` allows us the rank meshes based on proximity to the camera.
+     * Mitigates awkward overlap of different meshes.
+     * */
+    public static class MeshRankNode implements Comparable {
+        double distance;
+        Mesh mesh;
+        public MeshRankNode(Mesh mesh, double distance) {
+            this.mesh = mesh;
+            this.distance = distance;
+        }
+        @Override
+        public int compareTo(Object o) {
+            if (o instanceof MeshRankNode other) {
+                return Double.compare(other.distance, this.distance);
+            }
+            throw new IllegalArgumentException();
+        }
 
+    }
+    private int displayWidth;
+    private int displayHeight;
+    private double verticalViewAngle;
+    private double focalLength;
+    private final Coordinate camera = new Coordinate(0, 0, 0);
     /**
      * Initializes StdDraw parameters and launches the StdDraw window. w and h are the
      * width and height of the world in pixels.
      *
-     * @param w width of the window in pixels.
-     * @param h height of the window in pixels.
+     * @param width width of the window in pixels.
+     * @param height height of the window in pixels.
+     * @param fovY vertical view angle of the camera.
      */
-    public void initialize(int w, int h) {
-        this.width = w;
-        this.height = h;
-        StdDraw.setCanvasSize(width, height);
+    public void initialize(int width, int height, double fovY) {
+        this.displayWidth = width;
+        this.displayHeight = height;
+        this.verticalViewAngle = fovY;
+        this.focalLength = displayHeight / (2 * Math.tan(Math.toRadians(verticalViewAngle)));
 
+        StdDraw.setCanvasSize(width, height);
         StdDraw.setXscale(0, width);
         StdDraw.setYscale(0, height);
 
         StdDraw.clear(new Color(0, 0, 0));
-
         StdDraw.enableDoubleBuffering();
         StdDraw.show();
     }
 
     /**
-     * Bare-bones render method. Calls the render method of each individual entity.
-     *
+     * Clears the display then renders each entity within the world.
      * @param world current world state to be rendered.
      * */
     public void renderFrame(World world) {
         StdDraw.clear(new Color(0, 0, 0));
         StdDraw.enableDoubleBuffering();
         for (Entity entity : world.fetchEntities()) {
-            entity.render();
+            renderEntity(entity);
         }
         StdDraw.show();
+    }
+
+    /**
+     * Render each of an entity's meshes in decreasing order of distance to the camera.
+     * @param entity entity to be rendered.
+     * */
+    public void renderEntity(Entity entity) {
+        // map each mesh to its distance relative to the camera, and place within priority queue.
+        PriorityQueue<MeshRankNode> meshRank = new PriorityQueue<>();
+        for (Mesh mesh : entity.getMeshes()) {
+            Coordinate averagePosition = mesh.averagePosition();
+            double deltaXSquared = Math.pow(camera.getX() - averagePosition.getX(), 2);
+            double deltaYSquared = Math.pow(camera.getY() - averagePosition.getY(), 2);
+            double deltaZSquared = Math.pow(camera.getZ() - averagePosition.getZ(), 2);
+            double distanceToCamera = Math.sqrt(deltaXSquared + deltaYSquared + deltaZSquared);
+            meshRank.add(new MeshRankNode(mesh, distanceToCamera));
+        }
+        // render each mesh in decreasing order relative to the camera to mitigate rendering overlap.
+        while (!meshRank.isEmpty()) {
+            renderMesh(meshRank.remove().mesh);
+        }
+    }
+
+    /**
+     * Draw and fill the mesh using StdDraw library.
+     * @param mesh mesh to be rendered.
+     * */
+    public void renderMesh(Mesh mesh) {
+        StdDraw.setPenColor(mesh.getColor());
+        int numVertices = mesh.getNumVertices();
+        double[] xVertices = new double[numVertices];
+        double[] yVertices = new double[numVertices];
+        for (int i = 0; i < numVertices; i++) {
+            Coordinate transformed = transformCoordinate(mesh.getVertices()[i]);
+            xVertices[i] = transformed.getX() + (double) displayWidth / 2;
+            yVertices[i] = transformed.getY() + (double) displayHeight / 2;
+        }
+        StdDraw.filledPolygon(xVertices, yVertices);
+    }
+
+    /**
+     * Transform a 3D coordinate to a 2D projection on screen.
+     * @param position 3D position within world.
+     * @return renderable 2D coordinate.
+     * */
+    public Coordinate transformCoordinate(Coordinate position) {
+        // D = (dX, dY, dz) -> position of point A with respect to a coordinate system defined by the camera
+        double dX = position.getX() - camera.getX();
+        double dY = position.getY() - camera.getY();
+        double dZ = position.getZ() - camera.getZ();
+        // E = (eX, eY, eZ) -> position of the display surface plane position relative to the camera pinhole
+        double eX = 0;
+        double eY = 0;
+        double eZ = focalLength;
+        // (bX, bY) -> transformed position on the 2d screen surface
+        double bX = (double) ((eZ / dZ) * dX + eX);
+        double bY = (double) ((eZ / dZ) * dY + eY);
+        return new Coordinate(bX, bY, 0);
     }
 }
 

--- a/src/engine/Renderer.java
+++ b/src/engine/Renderer.java
@@ -119,7 +119,7 @@ public class Renderer {
         double Z = position.getZ() - cameraPosition.getZ();
         // Theta = (thetaX, thetaY, thetaZ) -> tait-bryan angles
         Coordinate cameraTilt = camera.getCameraTilt();
-        double thetaX = Math.toRadians(cameraTilt.getX()); // pitch
+        double thetaX = -Math.toRadians(cameraTilt.getX()); // pitch
         double thetaY = -Math.toRadians(cameraTilt.getY() - 90); // yaw
         double thetaZ = Math.toRadians(cameraTilt.getZ()); // roll
         // I have no idea if this is going to work

--- a/src/engine/Renderer.java
+++ b/src/engine/Renderer.java
@@ -5,6 +5,7 @@ import util.Coordinate;
 import util.Mesh;
 import world.Entity;
 import world.World;
+import world.Camera;
 
 import java.awt.Color;
 import java.util.PriorityQueue;
@@ -34,7 +35,7 @@ public class Renderer {
     private int displayHeight;
     private double verticalViewAngle;
     private double focalLength;
-    private final Coordinate camera = new Coordinate(0, 0, 0);
+    private Camera camera;
     /**
      * Initializes StdDraw parameters and launches the StdDraw window. w and h are the
      * width and height of the world in pixels.
@@ -43,7 +44,8 @@ public class Renderer {
      * @param height height of the window in pixels.
      * @param fovY vertical view angle of the camera.
      */
-    public void initialize(int width, int height, double fovY) {
+    public void initialize(Camera camera, int width, int height, double fovY) {
+        this.camera = camera;
         this.displayWidth = width;
         this.displayHeight = height;
         this.verticalViewAngle = fovY;
@@ -79,11 +81,9 @@ public class Renderer {
         // map each mesh to its distance relative to the camera, and place within priority queue.
         PriorityQueue<MeshRankNode> meshRank = new PriorityQueue<>();
         for (Mesh mesh : entity.getMeshes()) {
-            Coordinate averagePosition = mesh.averagePosition();
-            double deltaXSquared = Math.pow(camera.getX() - averagePosition.getX(), 2);
-            double deltaYSquared = Math.pow(camera.getY() - averagePosition.getY(), 2);
-            double deltaZSquared = Math.pow(camera.getZ() - averagePosition.getZ(), 2);
-            double distanceToCamera = Math.sqrt(deltaXSquared + deltaYSquared + deltaZSquared);
+            Coordinate meshPosition = mesh.averagePosition();
+            Coordinate cameraPosition = camera.getPosition();
+            double distanceToCamera = cameraPosition.distanceTo(meshPosition);
             meshRank.add(new MeshRankNode(mesh, distanceToCamera));
         }
         // render each mesh in decreasing order relative to the camera to mitigate rendering overlap.
@@ -116,9 +116,10 @@ public class Renderer {
      * */
     public Coordinate transformCoordinate(Coordinate position) {
         // D = (dX, dY, dz) -> position of point A with respect to a coordinate system defined by the camera
-        double dX = position.getX() - camera.getX();
-        double dY = position.getY() - camera.getY();
-        double dZ = position.getZ() - camera.getZ();
+        Coordinate cameraPosition = camera.getPosition();
+        double dX = position.getX() - cameraPosition.getX();
+        double dY = position.getY() - cameraPosition.getY();
+        double dZ = position.getZ() - cameraPosition.getZ();
         // E = (eX, eY, eZ) -> position of the display surface plane position relative to the camera pinhole
         double eX = 0;
         double eY = 0;

--- a/src/engine/Renderer.java
+++ b/src/engine/Renderer.java
@@ -81,7 +81,7 @@ public class Renderer {
         for (Mesh mesh : entity.getMeshes()) {
             Coordinate meshPosition = mesh.averagePosition();
             Coordinate cameraPosition = camera.getPosition();
-            double distanceToCamera = cameraPosition.distanceTo(meshPosition);
+            double distanceToCamera = cameraPosition.distance3D(meshPosition);
             meshRank.add(new MeshRankNode(mesh, distanceToCamera));
         }
         // render each mesh in decreasing order relative to the camera to mitigate rendering overlap.

--- a/src/engine/Renderer.java
+++ b/src/engine/Renderer.java
@@ -38,6 +38,7 @@ public class Renderer {
      * */
     public void renderFrame(World world) {
         StdDraw.clear(new Color(0, 0, 0));
+        StdDraw.enableDoubleBuffering();
         for (Entity entity : world.fetchEntities()) {
             entity.render();
         }

--- a/src/engine/Renderer.java
+++ b/src/engine/Renderer.java
@@ -33,7 +33,6 @@ public class Renderer {
     }
     private int displayWidth;
     private int displayHeight;
-    private double verticalViewAngle;
     private double focalLength;
     private Camera camera;
     /**
@@ -44,11 +43,10 @@ public class Renderer {
      * @param height height of the window in pixels.
      * @param fovY vertical view angle of the camera.
      */
-    public void initialize(Camera camera, int width, int height, double fovY) {
+    public void initialize(Camera camera, int width, int height, double verticalViewAngle) {
         this.camera = camera;
         this.displayWidth = width;
         this.displayHeight = height;
-        this.verticalViewAngle = fovY;
         this.focalLength = displayHeight / (2 * Math.tan(Math.toRadians(verticalViewAngle)));
 
         StdDraw.setCanvasSize(width, height);
@@ -115,11 +113,19 @@ public class Renderer {
      * @return renderable 2D coordinate.
      * */
     public Coordinate transformCoordinate(Coordinate position) {
-        // D = (dX, dY, dz) -> position of point A with respect to a coordinate system defined by the camera
         Coordinate cameraPosition = camera.getPosition();
-        double dX = position.getX() - cameraPosition.getX();
-        double dY = position.getY() - cameraPosition.getY();
-        double dZ = position.getZ() - cameraPosition.getZ();
+        double X = position.getX() - cameraPosition.getX();
+        double Y = position.getY() - cameraPosition.getY();
+        double Z = position.getZ() - cameraPosition.getZ();
+        // Theta = (thetaX, thetaY, thetaZ) -> tait-bryan angles
+        Coordinate cameraTilt = camera.getCameraTilt();
+        double thetaX = Math.toRadians(cameraTilt.getX()); // pitch
+        double thetaY = Math.toRadians(cameraTilt.getY()); // yaw
+        double thetaZ = Math.toRadians(cameraTilt.getZ()); // roll
+        // I have no idea if this is going to work
+        double dX = Math.cos(thetaY) * (Math.sin(thetaZ) * Y + Math.cos(thetaZ) * X) - Math.sin(thetaY) * Z;
+        double dY = Math.sin(thetaX) * (Math.cos(thetaY) * Z + Math.sin(thetaY) * (Math.sin(thetaZ) * Y + Math.cos(thetaZ) * X)) + Math.cos(thetaX) * (Math.cos(thetaZ) * Y - Math.sin(thetaZ) * X);
+        double dZ = Math.cos(thetaX) * (Math.cos(thetaY) * Z + Math.sin(thetaY) * (Math.sin(thetaZ) * Y + Math.cos(thetaZ) * X)) - Math.sin(thetaX) * (Math.cos(thetaZ) * Y - Math.sin(thetaZ) * X);
         // E = (eX, eY, eZ) -> position of the display surface plane position relative to the camera pinhole
         double eX = 0;
         double eY = 0;

--- a/src/engine/Renderer.java
+++ b/src/engine/Renderer.java
@@ -120,7 +120,7 @@ public class Renderer {
         // Theta = (thetaX, thetaY, thetaZ) -> tait-bryan angles
         Coordinate cameraTilt = camera.getCameraTilt();
         double thetaX = Math.toRadians(cameraTilt.getX()); // pitch
-        double thetaY = Math.toRadians(cameraTilt.getY()); // yaw
+        double thetaY = -Math.toRadians(cameraTilt.getY() - 90); // yaw
         double thetaZ = Math.toRadians(cameraTilt.getZ()); // roll
         // I have no idea if this is going to work
         double dX = Math.cos(thetaY) * (Math.sin(thetaZ) * Y + Math.cos(thetaZ) * X) - Math.sin(thetaY) * Z;

--- a/src/util/Coordinate.java
+++ b/src/util/Coordinate.java
@@ -23,7 +23,7 @@ public class Coordinate {
         double deltaZSquared = Math.pow(getZ() - other.getZ(), 2);
         return Math.sqrt(deltaXSquared + deltaYSquared + deltaZSquared);
     }
-    public double[] coordinateToArray() {
+    public double[] toArray() {
         return new double[]{x, y, z};
     }
 }

--- a/src/util/Coordinate.java
+++ b/src/util/Coordinate.java
@@ -1,0 +1,24 @@
+package util;
+
+public class Coordinate {
+    public double x;
+    public double y;
+    public double z;
+
+    public Coordinate(double xInitial, double yInitial, double zInitial) {
+        this.x = xInitial;
+        this.y = yInitial;
+        this.z = zInitial;
+    }
+
+    public double getX() { return this.x; };
+    public double getY() {
+        return this.y;
+    };
+    public double getZ() {
+        return this.z;
+    };
+    public double[] coordinateToArray() {
+        return new double[]{x, y, z};
+    }
+}

--- a/src/util/Coordinate.java
+++ b/src/util/Coordinate.java
@@ -17,11 +17,16 @@ public class Coordinate {
     public double getZ() {
         return this.z;
     };
-    public double distanceTo(Coordinate other) {
+    public double distance3D(Coordinate other) {
         double deltaXSquared = Math.pow(getX() - other.getX(), 2);
         double deltaYSquared = Math.pow(getY() - other.getY(), 2);
         double deltaZSquared = Math.pow(getZ() - other.getZ(), 2);
         return Math.sqrt(deltaXSquared + deltaYSquared + deltaZSquared);
+    }
+    public double distanceXZ(Coordinate other) {
+        double deltaXSquared = Math.pow(getX() - other.getX(), 2);
+        double deltaZSquared = Math.pow(getZ() - other.getZ(), 2);
+        return Math.sqrt(deltaXSquared + deltaZSquared);
     }
     public double[] toArray() {
         return new double[]{x, y, z};

--- a/src/util/Coordinate.java
+++ b/src/util/Coordinate.java
@@ -10,7 +10,6 @@ public class Coordinate {
         this.y = yInitial;
         this.z = zInitial;
     }
-
     public double getX() { return this.x; };
     public double getY() {
         return this.y;
@@ -18,6 +17,12 @@ public class Coordinate {
     public double getZ() {
         return this.z;
     };
+    public double distanceTo(Coordinate other) {
+        double deltaXSquared = Math.pow(getX() - other.getX(), 2);
+        double deltaYSquared = Math.pow(getY() - other.getY(), 2);
+        double deltaZSquared = Math.pow(getZ() - other.getZ(), 2);
+        return Math.sqrt(deltaXSquared + deltaYSquared + deltaZSquared);
+    }
     public double[] coordinateToArray() {
         return new double[]{x, y, z};
     }

--- a/src/util/Mesh.java
+++ b/src/util/Mesh.java
@@ -3,12 +3,26 @@ import java.awt.Color;
 import java.util.List;
 
 public class Mesh {
-    public Color color;
-    public List<Coordinate> vertices;
+    private Color color;
+    private Coordinate[] vertices;
+    private int numVertices;
 
-    public Mesh(Color color, List<Coordinate> vertices) {
+    public Mesh(Coordinate[] vertices, Color color) {
         this.color = color;
         this.vertices = vertices;
+        this.numVertices = vertices.length;
+    }
+
+    public Coordinate[] getVertices() {
+        return vertices;
+    }
+
+    public Color getColor() {
+        return color;
+    }
+
+    public int getNumVertices() {
+        return numVertices;
     }
 
 }

--- a/src/util/Mesh.java
+++ b/src/util/Mesh.java
@@ -1,0 +1,14 @@
+package util;
+import java.awt.Color;
+import java.util.List;
+
+public class Mesh {
+    public Color color;
+    public List<Coordinate> vertices;
+
+    public Mesh(Color color, List<Coordinate> vertices) {
+        this.color = color;
+        this.vertices = vertices;
+    }
+
+}

--- a/src/util/Mesh.java
+++ b/src/util/Mesh.java
@@ -1,18 +1,15 @@
 package util;
 import java.awt.Color;
-import java.util.List;
 
 public class Mesh {
     private Color color;
     private Coordinate[] vertices;
     private int numVertices;
-
     public Mesh(Coordinate[] vertices, Color color) {
         this.color = color;
         this.vertices = vertices;
         this.numVertices = vertices.length;
     }
-
     public Coordinate[] getVertices() {
         return vertices;
     }
@@ -25,4 +22,19 @@ public class Mesh {
         return numVertices;
     }
 
+    /**
+     * Returns the average position on a mesh for computing basic rendering order.
+     * @return coordinate representing average position.
+     */
+    public Coordinate averagePosition() {
+        double xSum = 0;
+        double ySum = 0;
+        double zSum = 0;
+        for (Coordinate vertex : vertices) {
+            xSum += vertex.getX();
+            ySum += vertex.getY();
+            zSum += vertex.getZ();
+        }
+        return new Coordinate(xSum / numVertices, ySum / numVertices, zSum / numVertices);
+    }
 }

--- a/src/world/Camera.java
+++ b/src/world/Camera.java
@@ -1,0 +1,23 @@
+package world;
+
+public class Camera extends Entity {
+    public double pitch;
+    public double yaw;
+    public Camera(double x, double y, double z) {
+        super(x, y, z);
+        this.pitch = 0;
+        this.yaw = 0;
+    }
+    public void moveFrontal(double distance) {
+        double deltaFrontal = distance * Math.cos(Math.toRadians(yaw));
+        double deltaLateral = distance * Math.sin(Math.toRadians(yaw));
+        this.zPosition += deltaFrontal;
+        this.xPosition += deltaLateral;
+    }
+    public void moveLateral(double distance) {
+        double deltaFrontal = distance * Math.sin(Math.toRadians(yaw));
+        double deltaLateral = distance * Math.cos(Math.toRadians(yaw));
+        this.zPosition += deltaFrontal;
+        this.xPosition += deltaLateral;
+    }
+}

--- a/src/world/Camera.java
+++ b/src/world/Camera.java
@@ -48,14 +48,18 @@ public class Camera extends Entity {
     public void rotateAround(Entity target, double degree) {
         Coordinate cameraPosition = getPosition();
         Coordinate targetPosition = target.getPosition();
+        // calculate the angle of the camera relative to the target
+        double deltaX1 = cameraPosition.getX() - targetPosition.getX();
+        double deltaZ1 = cameraPosition.getZ() - targetPosition.getZ();
+        double relativeToTarget = Math.atan2(deltaZ1, deltaX1);
+        // calculate the new camera position relative to the target position
         double distanceBetween = cameraPosition.distanceTo(targetPosition);
-
-        double deltaFrontal = distanceBetween * (1 - Math.cos(Math.toRadians(degree)));
-        double deltaLateral = distanceBetween * Math.sin(Math.toRadians(degree));
-
-        this.yaw += -degree;
-        this.zPosition += deltaFrontal;
-        this.xPosition += deltaLateral;
+        double deltaX2 = distanceBetween * Math.cos(relativeToTarget + Math.toRadians(degree));
+        double deltaZ2 = distanceBetween * Math.sin(relativeToTarget + Math.toRadians(degree));
+        // update camera position and view angle
+        this.xPosition = targetPosition.getX() + deltaX2;
+        this.zPosition = targetPosition.getZ() + deltaZ2;
+        pointToward(target);
     }
     public Coordinate getCameraTilt() {
         return new Coordinate(pitch, yaw, roll);

--- a/src/world/Camera.java
+++ b/src/world/Camera.java
@@ -33,6 +33,18 @@ public class Camera extends Entity {
         // TODO: floor mod degree to avoid overflow (view angles could be integers with limited precisions)
         this.yaw += degree;
     }
+    public void pointToward(Entity target) {
+        Coordinate cameraPosition = getPosition();
+        Coordinate targetPosition = target.getPosition();
+        // calculate the yaw (right-left view)
+        double deltaX = targetPosition.getX() - cameraPosition.getX();
+        double deltaZ = targetPosition.getZ() - cameraPosition.getZ();
+        this.yaw = Math.toDegrees(Math.atan2(deltaZ, deltaX));
+        // calculate the pitch (up-down view)
+        double deltaY = targetPosition.getY() - cameraPosition.getY();
+        double xzDistance = cameraPosition.distanceTo(targetPosition);
+        this.pitch = Math.toDegrees(Math.atan2(deltaY, xzDistance));
+    }
     public void rotateAround(Entity target, double degree) {
         Coordinate cameraPosition = getPosition();
         Coordinate targetPosition = target.getPosition();

--- a/src/world/Camera.java
+++ b/src/world/Camera.java
@@ -42,7 +42,7 @@ public class Camera extends Entity {
         this.yaw = Math.toDegrees(Math.atan2(deltaZ, deltaX));
         // calculate the pitch (up-down view)
         double deltaY = targetPosition.getY() - cameraPosition.getY();
-        double xzDistance = cameraPosition.distanceTo(targetPosition);
+        double xzDistance = cameraPosition.distanceXZ(targetPosition);
         this.pitch = Math.toDegrees(Math.atan2(deltaY, xzDistance));
     }
     public void rotateAround(Entity target, double degree) {
@@ -53,9 +53,9 @@ public class Camera extends Entity {
         double deltaZ1 = cameraPosition.getZ() - targetPosition.getZ();
         double relativeToTarget = Math.atan2(deltaZ1, deltaX1);
         // calculate the new camera position relative to the target position
-        double distanceBetween = cameraPosition.distanceTo(targetPosition);
-        double deltaX2 = distanceBetween * Math.cos(relativeToTarget + Math.toRadians(degree));
-        double deltaZ2 = distanceBetween * Math.sin(relativeToTarget + Math.toRadians(degree));
+        double xzDistance = cameraPosition.distanceXZ(targetPosition);
+        double deltaX2 = xzDistance * Math.cos(relativeToTarget + Math.toRadians(degree));
+        double deltaZ2 = xzDistance * Math.sin(relativeToTarget + Math.toRadians(degree));
         // update camera position and view angle
         this.xPosition = targetPosition.getX() + deltaX2;
         this.zPosition = targetPosition.getZ() + deltaZ2;

--- a/src/world/Camera.java
+++ b/src/world/Camera.java
@@ -8,22 +8,20 @@ public class Camera extends Entity {
     public Camera(double x, double y, double z) {
         super(x, y, z);
         this.pitch = 0;
-        this.yaw = 0;
+        this.yaw = 90;
         this.roll = 0;
     }
     public void moveFrontal(double distance) {
-        // TODO: change variable names here
-        double deltaFrontal = distance * Math.cos(Math.toRadians(yaw));
-        double deltaLateral = distance * Math.sin(Math.toRadians(yaw));
-        this.zPosition += deltaFrontal;
-        this.xPosition += deltaLateral;
+        moveInDirection(distance, this.yaw);
     }
     public void moveLateral(double distance) {
-        // TODO: change variable names here
-        double deltaFrontal = distance * Math.cos(Math.toRadians(yaw + 90));
-        double deltaLateral = distance * Math.sin(Math.toRadians(yaw + 90));
-        this.zPosition += deltaFrontal;
-        this.xPosition += deltaLateral;
+        moveInDirection(distance, this.yaw - 90);
+    }
+    public void moveInDirection(double distance, double angle) {
+        double deltaX = distance * Math.cos(Math.toRadians(angle));
+        double deltaZ = distance * Math.sin(Math.toRadians(angle));
+        this.xPosition += deltaX;
+        this.zPosition += deltaZ;
     }
     public void moveTransverse(double distance) {
         this.yPosition += distance;
@@ -32,6 +30,7 @@ public class Camera extends Entity {
         this.pitch += degree;
     }
     public void rotateYaw(double degree) {
+        // TODO: floor mod degree to avoid overflow (view angles could be integers with limited precisions)
         this.yaw += degree;
     }
     public void rotateAround(Entity target, double degree) {

--- a/src/world/Camera.java
+++ b/src/world/Camera.java
@@ -25,11 +25,26 @@ public class Camera extends Entity {
         this.zPosition += deltaFrontal;
         this.xPosition += deltaLateral;
     }
+    public void moveTransverse(double distance) {
+        this.yPosition += distance;
+    }
     public void rotatePitch(double degree) {
         this.pitch += degree;
     }
     public void rotateYaw(double degree) {
         this.yaw += degree;
+    }
+    public void rotateAround(Entity target, double degree) {
+        Coordinate cameraPosition = getPosition();
+        Coordinate targetPosition = target.getPosition();
+        double distanceBetween = cameraPosition.distanceTo(targetPosition);
+
+        double deltaFrontal = distanceBetween * (1 - Math.cos(Math.toRadians(degree)));
+        double deltaLateral = distanceBetween * Math.sin(Math.toRadians(degree));
+
+        this.yaw += -degree;
+        this.zPosition += deltaFrontal;
+        this.xPosition += deltaLateral;
     }
     public Coordinate getCameraTilt() {
         return new Coordinate(pitch, yaw, roll);

--- a/src/world/Camera.java
+++ b/src/world/Camera.java
@@ -1,23 +1,37 @@
 package world;
+import util.Coordinate;
 
 public class Camera extends Entity {
     public double pitch;
     public double yaw;
+    public double roll;
     public Camera(double x, double y, double z) {
         super(x, y, z);
         this.pitch = 0;
         this.yaw = 0;
+        this.roll = 0;
     }
     public void moveFrontal(double distance) {
+        // TODO: change variable names here
         double deltaFrontal = distance * Math.cos(Math.toRadians(yaw));
         double deltaLateral = distance * Math.sin(Math.toRadians(yaw));
         this.zPosition += deltaFrontal;
         this.xPosition += deltaLateral;
     }
     public void moveLateral(double distance) {
-        double deltaFrontal = distance * Math.sin(Math.toRadians(yaw));
-        double deltaLateral = distance * Math.cos(Math.toRadians(yaw));
+        // TODO: change variable names here
+        double deltaFrontal = distance * Math.cos(Math.toRadians(yaw + 90));
+        double deltaLateral = distance * Math.sin(Math.toRadians(yaw + 90));
         this.zPosition += deltaFrontal;
         this.xPosition += deltaLateral;
+    }
+    public void rotatePitch(double degree) {
+        this.pitch += degree;
+    }
+    public void rotateYaw(double degree) {
+        this.yaw += degree;
+    }
+    public Coordinate getCameraTilt() {
+        return new Coordinate(pitch, yaw, roll);
     }
 }

--- a/src/world/Cube.java
+++ b/src/world/Cube.java
@@ -1,0 +1,20 @@
+package world;
+
+import edu.princeton.cs.algs4.StdDraw;
+
+public class Cube extends Entity {
+    public int sideLength;
+    public int xPosition;
+    public int yPosition;
+
+    public Cube(int x, int y, int z, int length) {
+        super(x, y, z);
+        sideLength = length;
+    }
+
+    public void render() {
+        StdDraw.setPenColor(StdDraw.RED);
+        StdDraw.filledSquare(xPosition, yPosition, (float) sideLength / 2);
+    }
+
+}

--- a/src/world/Cube.java
+++ b/src/world/Cube.java
@@ -1,5 +1,91 @@
 package world;
 
+import edu.princeton.cs.algs4.StdDraw;
+import util.Coordinate;
+import util.Mesh;
+
+import java.util.ArrayList;
+
 public class Cube extends Entity {
 
+    int sideLength;
+    ArrayList<Coordinate> vertices;
+    ArrayList<Mesh> meshes;
+
+    public Cube(int x, int y, int z, int sideLength) {
+        super(x, y, z);
+        this.sideLength = sideLength;
+        createVertices();
+    }
+
+    public void createVertices() {
+        vertices = new ArrayList<>();
+        meshes = new ArrayList<>();
+        int halfLength = sideLength / 2;
+        // insert vertices clockwise from bottom left corner
+        Coordinate vertex1 = new Coordinate(xPosition - halfLength, yPosition - halfLength, zPosition - halfLength);
+        Coordinate vertex2 = new Coordinate(xPosition - halfLength, yPosition + halfLength, zPosition - halfLength);
+        Coordinate vertex3 = new Coordinate(xPosition + halfLength, yPosition + halfLength, zPosition - halfLength);
+        Coordinate vertex4 = new Coordinate(xPosition + halfLength, yPosition - halfLength, zPosition - halfLength);
+        Coordinate vertex5 = new Coordinate(xPosition - halfLength, yPosition - halfLength, zPosition + halfLength);
+        Coordinate vertex6 = new Coordinate(xPosition - halfLength, yPosition + halfLength, zPosition + halfLength);
+        Coordinate vertex7 = new Coordinate(xPosition + halfLength, yPosition + halfLength, zPosition + halfLength);
+        Coordinate vertex8 = new Coordinate(xPosition + halfLength, yPosition - halfLength, zPosition + halfLength);
+        vertices.add(vertex1);
+        vertices.add(vertex2);
+        vertices.add(vertex3);
+        vertices.add(vertex4);
+        vertices.add(vertex5);
+        vertices.add(vertex6);
+        vertices.add(vertex7);
+        vertices.add(vertex8);
+        Mesh frontFace = new Mesh(new Coordinate[]{vertex1, vertex2, vertex3, vertex4}, StdDraw.RED);
+        Mesh topFace = new Mesh(new Coordinate[]{vertex2, vertex6, vertex7, vertex3}, StdDraw.BLUE);
+//        Mesh bottomFace = new Mesh(new Coordinate[]{vertex1, vertex5, vertex8, vertex4}, StdDraw.GREEN);
+//        Mesh backFace = new Mesh(new Coordinate[]{vertex5, vertex6, vertex7, vertex8}, StdDraw.YELLOW);
+//        Mesh leftFace = new Mesh(new Coordinate[]{vertex1, vertex2, vertex5, vertex4}, StdDraw.ORANGE);
+        Mesh rightFace = new Mesh(new Coordinate[]{vertex4, vertex3, vertex7, vertex8}, StdDraw.WHITE);
+        meshes.add(frontFace);
+        meshes.add(topFace);
+//        meshes.add(bottomFace);
+//        meshes.add(backFace);
+//        meshes.add(leftFace);
+        meshes.add(rightFace);
+    }
+
+    public void render() {
+        for (Mesh mesh : meshes) {
+            renderMesh(mesh);
+        }
+    }
+
+    public void renderMesh(Mesh mesh) {
+        Coordinate origin = new Coordinate(0, 0, 0);
+        StdDraw.setPenColor(mesh.getColor());
+        int numVertices = mesh.getNumVertices();
+        double[] xVertices = new double[numVertices];
+        double[] yVertices = new double[numVertices];
+        for (int i = 0; i < numVertices; i++) {
+            Coordinate transformed = transformCoordinate(mesh.getVertices()[i], origin);
+            xVertices[i] = transformed.getX() + 300;
+            yVertices[i] = transformed.getY() + 300;
+        }
+        StdDraw.filledPolygon(xVertices, yVertices);
+    }
+
+    public Coordinate transformCoordinate(Coordinate entityCoord, Coordinate cameraCoord) {
+        double dX = entityCoord.getX() - cameraCoord.getX();
+        double dY = entityCoord.getY() - cameraCoord.getY();
+        double dZ = entityCoord.getZ() - cameraCoord.getZ();
+
+        double focalLength = 50;
+        // E = (eX, eY, eZ) coordinate represents the display surface's position relative to the camera pinhole
+        double eX = 0;
+        double eY = 0;
+        double eZ = focalLength;
+        // (bX, bY) position on the 2d screen surface
+        double bX = (double) ((eZ / dZ) * dX + eX);
+        double bY = (double) ((eZ / dZ) * dY + eY);
+        return new Coordinate(bX, bY, 0);
+    }
 }

--- a/src/world/Cube.java
+++ b/src/world/Cube.java
@@ -1,20 +1,5 @@
 package world;
 
-import edu.princeton.cs.algs4.StdDraw;
-
 public class Cube extends Entity {
-    public int sideLength;
-    public int xPosition;
-    public int yPosition;
-
-    public Cube(int x, int y, int z, int length) {
-        super(x, y, z);
-        sideLength = length;
-    }
-
-    public void render() {
-        StdDraw.setPenColor(StdDraw.RED);
-        StdDraw.filledSquare(xPosition, yPosition, (float) sideLength / 2);
-    }
 
 }

--- a/src/world/Cube.java
+++ b/src/world/Cube.java
@@ -7,20 +7,19 @@ import util.Mesh;
 import java.util.ArrayList;
 
 public class Cube extends Entity {
-
     int sideLength;
     ArrayList<Coordinate> vertices;
-    ArrayList<Mesh> meshes;
-
     public Cube(int x, int y, int z, int sideLength) {
         super(x, y, z);
         this.sideLength = sideLength;
-        createVertices();
+        createCube();
     }
 
-    public void createVertices() {
+    /**
+     * Initialize a basic multicolored cube for testing 3d projections.
+     * */
+    public void createCube() {
         vertices = new ArrayList<>();
-        meshes = new ArrayList<>();
         int halfLength = sideLength / 2;
         // insert vertices clockwise from bottom left corner
         Coordinate vertex1 = new Coordinate(xPosition - halfLength, yPosition - halfLength, zPosition - halfLength);
@@ -39,53 +38,19 @@ public class Cube extends Entity {
         vertices.add(vertex6);
         vertices.add(vertex7);
         vertices.add(vertex8);
+        // create faces of the cube
+        meshes = new ArrayList<>();
         Mesh frontFace = new Mesh(new Coordinate[]{vertex1, vertex2, vertex3, vertex4}, StdDraw.RED);
         Mesh topFace = new Mesh(new Coordinate[]{vertex2, vertex6, vertex7, vertex3}, StdDraw.BLUE);
-//        Mesh bottomFace = new Mesh(new Coordinate[]{vertex1, vertex5, vertex8, vertex4}, StdDraw.GREEN);
-//        Mesh backFace = new Mesh(new Coordinate[]{vertex5, vertex6, vertex7, vertex8}, StdDraw.YELLOW);
-//        Mesh leftFace = new Mesh(new Coordinate[]{vertex1, vertex2, vertex5, vertex4}, StdDraw.ORANGE);
+        Mesh bottomFace = new Mesh(new Coordinate[]{vertex1, vertex5, vertex8, vertex4}, StdDraw.GREEN);
+        Mesh backFace = new Mesh(new Coordinate[]{vertex5, vertex6, vertex7, vertex8}, StdDraw.YELLOW);
+        Mesh leftFace = new Mesh(new Coordinate[]{vertex1, vertex2, vertex6, vertex5}, StdDraw.ORANGE);
         Mesh rightFace = new Mesh(new Coordinate[]{vertex4, vertex3, vertex7, vertex8}, StdDraw.WHITE);
         meshes.add(frontFace);
         meshes.add(topFace);
-//        meshes.add(bottomFace);
-//        meshes.add(backFace);
-//        meshes.add(leftFace);
+        meshes.add(bottomFace);
+        meshes.add(backFace);
+        meshes.add(leftFace);
         meshes.add(rightFace);
-    }
-
-    public void render() {
-        for (Mesh mesh : meshes) {
-            renderMesh(mesh);
-        }
-    }
-
-    public void renderMesh(Mesh mesh) {
-        Coordinate origin = new Coordinate(0, 0, 0);
-        StdDraw.setPenColor(mesh.getColor());
-        int numVertices = mesh.getNumVertices();
-        double[] xVertices = new double[numVertices];
-        double[] yVertices = new double[numVertices];
-        for (int i = 0; i < numVertices; i++) {
-            Coordinate transformed = transformCoordinate(mesh.getVertices()[i], origin);
-            xVertices[i] = transformed.getX() + 300;
-            yVertices[i] = transformed.getY() + 300;
-        }
-        StdDraw.filledPolygon(xVertices, yVertices);
-    }
-
-    public Coordinate transformCoordinate(Coordinate entityCoord, Coordinate cameraCoord) {
-        double dX = entityCoord.getX() - cameraCoord.getX();
-        double dY = entityCoord.getY() - cameraCoord.getY();
-        double dZ = entityCoord.getZ() - cameraCoord.getZ();
-
-        double focalLength = 50;
-        // E = (eX, eY, eZ) coordinate represents the display surface's position relative to the camera pinhole
-        double eX = 0;
-        double eY = 0;
-        double eZ = focalLength;
-        // (bX, bY) position on the 2d screen surface
-        double bX = (double) ((eZ / dZ) * dX + eX);
-        double bY = (double) ((eZ / dZ) * dY + eY);
-        return new Coordinate(bX, bY, 0);
     }
 }

--- a/src/world/Entity.java
+++ b/src/world/Entity.java
@@ -1,9 +1,13 @@
 package world;
 
+import util.Mesh;
+import java.util.List;
+
 public class Entity {
     public int xPosition;
     public int yPosition;
     public int zPosition;
+    public List<Mesh> meshes;
 
     public Entity(int x, int y, int z) {
         xPosition = x;
@@ -11,6 +15,7 @@ public class Entity {
         zPosition = z;
     }
 
-    public void render() {
+    public List<Mesh> getMeshes() {
+        return this.meshes;
     }
 }

--- a/src/world/Entity.java
+++ b/src/world/Entity.java
@@ -1,15 +1,16 @@
 package world;
 
+import util.Coordinate;
 import util.Mesh;
 import java.util.List;
 
 public class Entity {
-    public int xPosition;
-    public int yPosition;
-    public int zPosition;
+    public double xPosition;
+    public double yPosition;
+    public double zPosition;
     public List<Mesh> meshes;
 
-    public Entity(int x, int y, int z) {
+    public Entity(double x, double y, double z) {
         xPosition = x;
         yPosition = y;
         zPosition = z;
@@ -17,5 +18,8 @@ public class Entity {
 
     public List<Mesh> getMeshes() {
         return this.meshes;
+    }
+    public Coordinate getPosition() {
+        return new Coordinate(xPosition, yPosition, zPosition);
     }
 }

--- a/src/world/Entity.java
+++ b/src/world/Entity.java
@@ -1,0 +1,16 @@
+package world;
+
+public class Entity {
+    public int xPosition;
+    public int yPosition;
+    public int zPosition;
+
+    public Entity(int x, int y, int z) {
+        xPosition = x;
+        yPosition = y;
+        zPosition = z;
+    }
+
+    public void render() {
+    }
+}

--- a/src/world/Square.java
+++ b/src/world/Square.java
@@ -1,0 +1,63 @@
+package world;
+
+import edu.princeton.cs.algs4.StdDraw;
+import util.Coordinate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Square extends Entity {
+    public int sideLength;
+    public List<Coordinate> vertices;
+
+    public Square(int x, int y, int z, int length) {
+        super(x, y, z);
+        sideLength = length;
+        createVertices();
+    }
+
+    public void createVertices() {
+        vertices = new ArrayList<>();
+        int halfLength = sideLength / 2;
+        // insert vertices clockwise from bottom left corner
+        Coordinate vertex1 = new Coordinate(xPosition - halfLength, yPosition - halfLength, zPosition);
+        Coordinate vertex2 = new Coordinate(xPosition - halfLength, yPosition + halfLength, zPosition);
+        Coordinate vertex3 = new Coordinate(xPosition + halfLength, yPosition + halfLength, zPosition);
+        Coordinate vertex4 = new Coordinate(xPosition + halfLength, yPosition - halfLength, zPosition);
+        vertices.add(vertex1);
+        vertices.add(vertex2);
+        vertices.add(vertex3);
+        vertices.add(vertex4);
+    }
+
+
+    public void render() {
+        StdDraw.setPenColor(StdDraw.RED);
+        Coordinate origin = new Coordinate(0, 0, 0);
+        double[] xVertices = new double[4];
+        double[] yVertices = new double[4];
+        for (int i = 0; i < vertices.size(); i++) {
+            Coordinate transformed = transformCoordinate(vertices.get(i), origin);
+            xVertices[i] = transformed.getX() + 300;
+            yVertices[i] = transformed.getY() + 300;
+        }
+        StdDraw.filledPolygon(xVertices, yVertices);
+    }
+
+    public Coordinate transformCoordinate(Coordinate entityCoord, Coordinate cameraCoord) {
+        double dX = entityCoord.getX() - cameraCoord.getX();
+        double dY = entityCoord.getY() - cameraCoord.getY();
+        double dZ = entityCoord.getZ() - cameraCoord.getZ();
+
+        double focalLength = 100;
+        // E = (eX, eY, eZ) coordinate represents the display surface's position relative to the camera pinhole
+        double eX = 0;
+        double eY = 0;
+        double eZ = focalLength;
+        // (bX, bY) position on the 2d screen surface
+        double bX = (double) ((eZ / dZ) * dX + eX);
+        double bY = (double) ((eZ / dZ) * dY + eY);
+        return new Coordinate(bX, bY, 0);
+    }
+
+}

--- a/src/world/World.java
+++ b/src/world/World.java
@@ -10,10 +10,13 @@ public class World {
         entities = new HashSet<>();
     }
 
+    /**
+     * Track new entity within the world.
+     * @param entity entity to be tracked.
+     * */
     public void insertEntity(Entity entity) {
         entities.add(entity);
     }
-
     /**
      * Returns all entities to be rendered onto the display.
      * */

--- a/src/world/World.java
+++ b/src/world/World.java
@@ -1,0 +1,19 @@
+package world;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class World {
+    // set of all render-able entities contained within the world.
+    public Set<Entity> entities;
+    public World() {
+        entities = new HashSet<>();
+    }
+
+    /**
+     * Returns all entities to be rendered onto the display.
+     * */
+    public Set<Entity> fetchEntities() {
+        return entities;
+    }
+}

--- a/src/world/World.java
+++ b/src/world/World.java
@@ -10,6 +10,10 @@ public class World {
         entities = new HashSet<>();
     }
 
+    public void insertEntity(Entity entity) {
+        entities.add(entity);
+    }
+
     /**
      * Returns all entities to be rendered onto the display.
      * */


### PR DESCRIPTION
## What's new in this PR

### Description

- Researched and implemented the linear transformations required to project 3D objects onto a 2D display.
- Created a `Camera` entity with adjustable position and focal length, upon which all objects are projected.
- Decomposed all objects into planar `Mesh`es to display textures and better approximate the surfaces of non-polygon objects.
- Created a fixed orbital viewing mode, allowing users to rotate around a target object while maintaining focus on the object.
- Separated functionality into 3 parts to prepare for future expansion and integration with other projects:
    - `World` class describes the virtual space that contains all renderable entities.
    - `Engine` class outlines movement controls for users to interact with the world.
    - `Renderer` class displays the world state to the user. 

### Screenshots

[//]: # "Required for frontend changes, otherwise optional but strongly recommended. Add screenshots of expected behavior - GIFs if you're feeling fancy!"

<img src="https://github.com/ronniebeggs/graphics-engine/assets/66931067/f7275f0b-4a15-482b-a137-c495b1697ed4" width="400" height="400">

### Resources

[CS184 Lecture 4 Slides: Transforms](https://cs184.eecs.berkeley.edu/sp23/lecture/4/transforms)
[3D Projection Formulas](https://en.wikipedia.org/wiki/3D_projection#Mathematical_formula)
[Tait-Bryan Convention For Describing Viewing Angles](https://en.wikipedia.org/wiki/Euler_angles#Tait%E2%80%93Bryan_angles)
[3D Rotation Conventions And Matrices](https://danceswithcode.net/engineeringnotes/rotations_in_3d/rotations_in_3d_part1.html)

### Next Steps
- Learn more about homogeneous coordinates, which apparently represent human vision more accurately.
- Create front and back clipping planes to avoid weird rendering behavior when coming too close to an object.
- Create a standardized system for rendering meshes that avoids overlapping textures.   